### PR TITLE
Add .gitignore for Node modules and Expo artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Node modules
+node_modules/
+
+# Expo/React Native build artifacts
+.expo/
+*.log
+
+# macOS system files
+.DS_Store


### PR DESCRIPTION
## Summary
- ignore Node `node_modules/` directory
- ignore Expo/React Native logs and `.expo/` directory
- ignore `.DS_Store` files

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684f05d3d6188322aaf2607b87b8dea1